### PR TITLE
Add 2fa confirm flow

### DIFF
--- a/resources/lang/en/two-factor.php
+++ b/resources/lang/en/two-factor.php
@@ -17,7 +17,16 @@ return [
 
         'regenerate' => [
             'label' => 'Regenerate recovery code',
-        ]
+        ],
+
+        'show-recovery-code' => [
+            'label' => 'Show recovery code',
+        ],
+
+    ],
+
+    'label' => [
+        'setup-key' => 'Setup key',
     ],
 
     'fields' => [
@@ -32,14 +41,18 @@ return [
         'password_confirm' => [
             'label' => 'Confirm password',
         ],
+
+        'code' => [
+            'label' => 'OTP code',
+        ],
     ],
 
     'messages' => [
         'throttled' => 'Too many register attempts. Please try again in :seconds seconds.',
         'enabled' => 'Two factor authentication has been enabled',
-        'scan-qr' => 'Scan the following QR code using your phone\'s authenticator application',
+        'scan-qr' => 'Scan the following QR code using your phone\'s authenticator application or enter the setup key.',
         'store-recovery-code' => 'Store these recovery codes in a secure place to recover access to your account if your two factor authentication device is lost.',
-        'confirm-two-factor-code' => 'Confirm the two factor code by entering the temporary code from the authenticator application',
+        'confirm-two-factor-code' => 'Confirm the two factor code by entering the OTP code from the authenticator application',
     ],
 
     'login' => [

--- a/resources/lang/en/two-factor.php
+++ b/resources/lang/en/two-factor.php
@@ -5,10 +5,19 @@ return [
 
     'heading' => 'Reset password',
 
+    'confirm-password' => [
+        'modal-heading' => "Sensitive action",
+        'modal-subheading' => "Please confirm your password before proceed this action.",
+    ],
+
     'buttons' => [
 
         'enable' => [
             'label' => 'Enable two factor auth',
+        ],
+
+        'confirm' => [
+            'label' => 'Enable',
         ],
 
         'disable' => [
@@ -45,6 +54,10 @@ return [
         'code' => [
             'label' => 'OTP code',
         ],
+
+        'current_password' => [
+            'label' => 'Password',
+        ]
     ],
 
     'messages' => [

--- a/resources/lang/en/two-factor.php
+++ b/resources/lang/en/two-factor.php
@@ -39,6 +39,7 @@ return [
         'enabled' => 'Two factor authentication has been enabled',
         'scan-qr' => 'Scan the following QR code using your phone\'s authenticator application',
         'store-recovery-code' => 'Store these recovery codes in a secure place to recover access to your account if your two factor authentication device is lost.',
+        'confirm-two-factor-code' => 'Confirm the two factor code by entering the temporary code from the authenticator application',
     ],
 
     'login' => [

--- a/resources/views/filament/pages/two-factor.blade.php
+++ b/resources/views/filament/pages/two-factor.blade.php
@@ -1,4 +1,8 @@
 <x-filament::page>
+    @php
+        $buttons = $this->getCachedButtons();
+    @endphp
+
     @if($this->showTwoFactor())
         <div class="flex items-center justify-center ">
             <div class="p-2 max-w-md  ">
@@ -58,22 +62,14 @@
 
                         <x-slot name="footer">
                             <div class="flex justify-between">
-                                <x-filament::button type="button" color="danger" wire:click="disableTwoFactorAuthentication">
-                                    {{__("filament-fortify::two-factor.buttons.disable.label")}}
-                                </x-filament::button>
+                                {{ $buttons['disable'] }}
 
                                 @if($showingRecoveryCodes)
-                                    <x-filament::button type="button" color="secondary" wire:click="regenerateRecoveryCodes">
-                                        {{__("filament-fortify::two-factor.buttons.regenerate.label")}}
-                                    </x-filament::button>
+                                    {{ $buttons['regenerate'] }}
                                 @elseif($showingConfirmation)
-                                    <x-filament::button type="button" color="success" wire:click="confirmTwoFactorAuthentication">
-                                    {{__("filament-fortify::two-factor.buttons.enable.label")}}
-                                    </x-filament::button>
+                                    {{ $buttons['confirm'] }}
                                 @else
-                                    <x-filament::button type="button" color="secondary" wire:click="showRecoveryCodes">
-                                        {{__("filament-fortify::two-factor.buttons.show-recovery-code.label")}}
-                                    </x-filament::button>
+                                    {{ $buttons['show-recovery-code'] }}
                                 @endif
                             </div>
                         </x-slot>
@@ -84,8 +80,6 @@
         </div>
 
     @else
-        <x-filament::button type="button" wire:click="enableTwoFactorAuthentication">
-            {{__("filament-fortify::two-factor.buttons.enable.label")}}
-        </x-filament::button>
+        {{ $buttons['enable'] }}
     @endif
 </x-filament::page>

--- a/resources/views/filament/pages/two-factor.blade.php
+++ b/resources/views/filament/pages/two-factor.blade.php
@@ -1,9 +1,94 @@
 <x-filament::page>
-    @if(auth()->user()->hasEnabledTwoFactorAuthentication())
+    @if(\Laravel\Fortify\Fortify::confirmsTwoFactorAuthentication() && auth()->user()->two_factor_secret && !auth()->user()->two_factor_confirmed_at)
         <div class="flex items-center justify-center ">
             <div class="p-2 max-w-md  ">
                 <x-filament::card>
-                    
+                    <div class="text-center space-y-8">
+                        <div>
+                            <div class="font-bold">
+                                {{__("filament-fortify::two-factor.messages.scan-qr")}}
+                            </div>
+                            <div class="flex items-center justify-center mt-2">
+                                {!!auth()->user()->twoFactorQrCodeSvg()!!}
+                            </div>
+                        </div>
+
+                        <div class="text-left text-sm">
+                            {{__("filament-fortify::two-factor.messages.store-recovery-code")}}
+                            <div class="flex items-center justify-center">
+                                <div class="mt-2 text-left text-sm">
+                                    @foreach((array) auth()->user()->recoveryCodes() as $index => $code)
+                                        <p class="mt-2">{{$index + 1}}) {{$code}}</p>
+                                    @endforeach
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="filament-forms-field-wrapper">
+                            <form method="POST" action="{{route('two-factor.confirm')}}">
+                                @csrf
+                                <div class="space-y-2">
+                                    <div class="flex items-center justify-between space-x-2 rtl:space-x-reverse">
+                                        <label
+                                            class="inline-flex items-center space-x-3 rtl:space-x-reverse filament-forms-field-wrapper-label"
+                                            for="code"
+                                        >
+                                            <span
+                                                class="text-sm font-medium leading-4 text-gray-700 dark:text-gray-300">
+                                                Confirm two factor code
+                                                <sup class="font-medium text-danger-700">*</sup>
+                                            </span>
+                                        </label>
+                                    </div>
+                                    <div
+                                        class="flex items-center space-x-1 rtl:space-x-reverse group filament-forms-text-input-component"
+                                    >
+                                        <div class="flex-1">
+                                            <input name="code" type="text" id="code"
+                                                   required=""
+                                                   class="block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70 dark:bg-gray-700 dark:text-white border-gray-300 dark:border-gray-600"
+                                            >
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="flex items-center space-x-1 rtl:space-x-reverse group filament-forms-button-component"
+                                    >
+                                        <div class="flex-1">
+                                            <x-filament::button type="submit" color="success">
+                                                {{__("filament-fortify::two-factor.buttons.enable.label")}}
+                                            </x-filament::button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+
+                        <x-slot name="footer">
+                            <div class="flex justify-between">
+                                <form method="POST" action="{{route('two-factor.recovery-codes')}}">
+                                    @csrf
+                                    <x-filament::button type="submit" color="secondary">
+                                        {{__("filament-fortify::two-factor.buttons.regenerate.label")}}
+                                    </x-filament::button>
+                                </form>
+                                <form method="POST" action="{{route('two-factor.disable')}}">
+                                    @method('DELETE')
+                                    @csrf
+                                    <x-filament::button type="submit" color="danger">
+                                        {{__("filament-fortify::two-factor.buttons.disable.label")}}
+                                    </x-filament::button>
+                                </form>
+                            </div>
+                        </x-slot>
+                    </div>
+
+                </x-filament::card>
+            </div>
+        </div>
+    @elseif(! \Laravel\Fortify\Fortify::confirmsTwoFactorAuthentication() && auth()->user()->two_factor_secret)
+        <div class="flex items-center justify-center ">
+            <div class="p-2 max-w-md  ">
+                <x-filament::card>
                     <div class="text-center space-y-8">
                         <div>
                             <div class="font-bold">
@@ -29,25 +114,33 @@
                             <div class="flex justify-between">
                                 <form method="POST" action="{{route('two-factor.recovery-codes')}}">
                                     @csrf
-                                        <x-filament::button type="submit" color="secondary">
-                                            {{__("filament-fortify::two-factor.buttons.regenerate.label")}}
-                                        </x-filament::button>
+                                    <x-filament::button type="submit" color="secondary">
+                                        {{__("filament-fortify::two-factor.buttons.regenerate.label")}}
+                                    </x-filament::button>
                                 </form>
                                 <form method="POST" action="{{route('two-factor.disable')}}">
                                     @method('DELETE')
                                     @csrf
-                                        <x-filament::button type="submit" color="danger">
-                                            {{__("filament-fortify::two-factor.buttons.disable.label")}}
-                                        </x-filament::button>
+                                    <x-filament::button type="submit" color="danger">
+                                        {{__("filament-fortify::two-factor.buttons.disable.label")}}
+                                    </x-filament::button>
                                 </form>
                             </div>
                         </x-slot>
                     </div>
-                        
+
                 </x-filament::card>
             </div>
         </div>
-    
+
+    @elseif(auth()->user()->hasEnabledTwoFactorAuthentication())
+        <form method="POST" action="{{route('two-factor.disable')}}">
+            @method('DELETE')
+            @csrf
+            <x-filament::button type="submit" color="danger">
+                {{__("filament-fortify::two-factor.buttons.disable.label")}}
+            </x-filament::button>
+        </form>
     @else
         <form method="POST" action="{{route('two-factor.enable')}}">
             @csrf

--- a/resources/views/filament/pages/two-factor.blade.php
+++ b/resources/views/filament/pages/two-factor.blade.php
@@ -35,7 +35,7 @@
                                         >
                                             <span
                                                 class="text-sm font-medium leading-4 text-gray-700 dark:text-gray-300">
-                                                Confirm two factor code
+                                                {{__('filament-fortify::two-factor.messages.confirm-two-factor-code')}}
                                                 <sup class="font-medium text-danger-700">*</sup>
                                             </span>
                                         </label>

--- a/resources/views/filament/pages/two-factor.blade.php
+++ b/resources/views/filament/pages/two-factor.blade.php
@@ -1,130 +1,80 @@
 <x-filament::page>
-    @if(\Laravel\Fortify\Fortify::confirmsTwoFactorAuthentication() && auth()->user()->two_factor_secret && !auth()->user()->two_factor_confirmed_at)
+    @if($this->showTwoFactor())
         <div class="flex items-center justify-center ">
             <div class="p-2 max-w-md  ">
                 <x-filament::card>
+
                     <div class="text-center space-y-8">
                         <div>
-                            <div class="font-bold">
-                                {{__("filament-fortify::two-factor.messages.scan-qr")}}
-                            </div>
-                            <div class="flex items-center justify-center mt-2">
-                                {!!auth()->user()->twoFactorQrCodeSvg()!!}
-                            </div>
+                            @unless($showingQrCode)
+                                <div class="font-bold">
+                                    {{__("filament-fortify::two-factor.messages.enabled")}}
+                                </div>
+                            @else
+                                <div class="font-bold">
+                                    {{__("filament-fortify::two-factor.messages.scan-qr")}}
+                                </div>
+                                <div class="flex items-center justify-center mt-2">
+                                    {!!auth()->user()->twoFactorQrCodeSvg()!!}
+                                </div>
+                                <br />
+                                <p class="text-sm">
+                                    {{ __('filament-fortify::two-factor.label.setup-key') }}: {{ decrypt(auth()->user()->two_factor_secret) }}
+                                </p>
+                            @endif
                         </div>
 
-                        <div class="text-left text-sm">
-                            {{__("filament-fortify::two-factor.messages.store-recovery-code")}}
-                            <div class="flex items-center justify-center">
-                                <div class="mt-2 text-left text-sm">
-                                    @foreach((array) auth()->user()->recoveryCodes() as $index => $code)
-                                        <p class="mt-2">{{$index + 1}}) {{$code}}</p>
-                                    @endforeach
+                        @if($showingRecoveryCodes)
+                            <div class="text-left text-sm">
+                                {{__("filament-fortify::two-factor.messages.store-recovery-code")}}
+                                <div class="flex items-center justify-center">
+                                    <div class="mt-2 text-left text-sm">
+                                        @foreach((array) auth()->user()->recoveryCodes() as $index => $code)
+                                            <p class="mt-2">{{$index + 1}}) {{$code}}</p>
+                                        @endforeach
+                                    </div>
                                 </div>
                             </div>
-                        </div>
+                        @endif
 
-                        <div class="filament-forms-field-wrapper">
-                            <form method="POST" action="{{route('two-factor.confirm')}}">
-                                @csrf
-                                <div class="space-y-2">
-                                    <div class="flex items-center justify-between space-x-2 rtl:space-x-reverse">
-                                        <label
-                                            class="inline-flex items-center space-x-3 rtl:space-x-reverse filament-forms-field-wrapper-label"
-                                            for="code"
-                                        >
-                                            <span
-                                                class="text-sm font-medium leading-4 text-gray-700 dark:text-gray-300">
-                                                {{__('filament-fortify::two-factor.messages.confirm-two-factor-code')}}
-                                                <sup class="font-medium text-danger-700">*</sup>
-                                            </span>
-                                        </label>
-                                    </div>
-                                    <div
-                                        class="flex items-center space-x-1 rtl:space-x-reverse group filament-forms-text-input-component"
+                        @if($showingConfirmation)
+                            <div>
+                                <div
+                                    class="flex items-center justify-between space-x-2 rtl:space-x-reverse"
+                                >
+                                    <span
+                                        class="text-sm font-medium leading-4 text-gray-700 dark:text-gray-300"
                                     >
-                                        <div class="flex-1">
-                                            <input name="code" type="text" id="code"
-                                                   required=""
-                                                   class="block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-600 focus:ring-1 focus:ring-inset focus:ring-primary-600 disabled:opacity-70 dark:bg-gray-700 dark:text-white border-gray-300 dark:border-gray-600"
-                                            >
-                                        </div>
-                                    </div>
-                                    <div
-                                        class="flex items-center space-x-1 rtl:space-x-reverse group filament-forms-button-component"
-                                    >
-                                        <div class="flex-1">
-                                            <x-filament::button type="submit" color="success">
-                                                {{__("filament-fortify::two-factor.buttons.enable.label")}}
-                                            </x-filament::button>
-                                        </div>
-                                    </div>
+                                        {{__('filament-fortify::two-factor.messages.confirm-two-factor-code')}}
+                                        <sup class="font-medium text-danger-700">*</sup>
+                                    </span>
                                 </div>
-                            </form>
-                        </div>
+                                <div class="mt-4">
+                                    {{ $this->form}}
+                                </div>
+                            </div>
+
+                        @endif
 
                         <x-slot name="footer">
                             <div class="flex justify-between">
-                                <form method="POST" action="{{route('two-factor.recovery-codes')}}">
-                                    @csrf
-                                    <x-filament::button type="submit" color="secondary">
+                                <x-filament::button type="button" color="danger" wire:click="disableTwoFactorAuthentication">
+                                    {{__("filament-fortify::two-factor.buttons.disable.label")}}
+                                </x-filament::button>
+
+                                @if($showingRecoveryCodes)
+                                    <x-filament::button type="button" color="secondary" wire:click="regenerateRecoveryCodes">
                                         {{__("filament-fortify::two-factor.buttons.regenerate.label")}}
                                     </x-filament::button>
-                                </form>
-                                <form method="POST" action="{{route('two-factor.disable')}}">
-                                    @method('DELETE')
-                                    @csrf
-                                    <x-filament::button type="submit" color="danger">
-                                        {{__("filament-fortify::two-factor.buttons.disable.label")}}
+                                @elseif($showingConfirmation)
+                                    <x-filament::button type="button" color="success" wire:click="confirmTwoFactorAuthentication">
+                                    {{__("filament-fortify::two-factor.buttons.enable.label")}}
                                     </x-filament::button>
-                                </form>
-                            </div>
-                        </x-slot>
-                    </div>
-
-                </x-filament::card>
-            </div>
-        </div>
-    @elseif(! \Laravel\Fortify\Fortify::confirmsTwoFactorAuthentication() && auth()->user()->two_factor_secret)
-        <div class="flex items-center justify-center ">
-            <div class="p-2 max-w-md  ">
-                <x-filament::card>
-                    <div class="text-center space-y-8">
-                        <div>
-                            <div class="font-bold">
-                                {{__("filament-fortify::two-factor.messages.scan-qr")}}
-                            </div>
-                            <div class="flex items-center justify-center mt-2">
-                                {!!auth()->user()->twoFactorQrCodeSvg()!!}
-                            </div>
-                        </div>
-
-                        <div class="text-left text-sm">
-                            {{__("filament-fortify::two-factor.messages.store-recovery-code")}}
-                            <div class="flex items-center justify-center">
-                                <div class="mt-2 text-left text-sm">
-                                    @foreach((array) auth()->user()->recoveryCodes() as $index => $code)
-                                        <p class="mt-2">{{$index + 1}}) {{$code}}</p>
-                                    @endforeach
-                                </div>
-                            </div>
-                        </div>
-
-                        <x-slot name="footer">
-                            <div class="flex justify-between">
-                                <form method="POST" action="{{route('two-factor.recovery-codes')}}">
-                                    @csrf
-                                    <x-filament::button type="submit" color="secondary">
-                                        {{__("filament-fortify::two-factor.buttons.regenerate.label")}}
+                                @else
+                                    <x-filament::button type="button" color="secondary" wire:click="showRecoveryCodes">
+                                        {{__("filament-fortify::two-factor.buttons.show-recovery-code.label")}}
                                     </x-filament::button>
-                                </form>
-                                <form method="POST" action="{{route('two-factor.disable')}}">
-                                    @method('DELETE')
-                                    @csrf
-                                    <x-filament::button type="submit" color="danger">
-                                        {{__("filament-fortify::two-factor.buttons.disable.label")}}
-                                    </x-filament::button>
-                                </form>
+                                @endif
                             </div>
                         </x-slot>
                     </div>
@@ -133,20 +83,9 @@
             </div>
         </div>
 
-    @elseif(auth()->user()->hasEnabledTwoFactorAuthentication())
-        <form method="POST" action="{{route('two-factor.disable')}}">
-            @method('DELETE')
-            @csrf
-            <x-filament::button type="submit" color="danger">
-                {{__("filament-fortify::two-factor.buttons.disable.label")}}
-            </x-filament::button>
-        </form>
     @else
-        <form method="POST" action="{{route('two-factor.enable')}}">
-            @csrf
-            <x-filament::button type="submit">
-                {{__("filament-fortify::two-factor.buttons.enable.label")}}
-            </x-filament::button>
-        </form>
+        <x-filament::button type="button" wire:click="enableTwoFactorAuthentication">
+            {{__("filament-fortify::two-factor.buttons.enable.label")}}
+        </x-filament::button>
     @endif
 </x-filament::page>

--- a/src/Pages/Concerns/ActionButtons.php
+++ b/src/Pages/Concerns/ActionButtons.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace WyChoong\FilamentFortify\Pages\Concerns;
+
+use Laravel\Fortify\Features;
+use Illuminate\Support\Facades\Auth;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
+
+trait ActionButtons
+{
+    use InteractsWithForms;
+
+    /**
+     * Indicates if two factor authentication QR code is being displayed.
+     *
+     * @var bool
+     */
+    public $showingQrCode = false;
+
+    /**
+     * Indicates if the two factor authentication confirmation input and button are being displayed.
+     *
+     * @var bool
+     */
+    public $showingConfirmation = false;
+
+    /**
+     * Indicates if two factor authentication recovery codes are being displayed.
+     *
+     * @var bool
+     */
+    public $showingRecoveryCodes = false;
+
+    public function mount()
+    {
+        $this->form->fill([
+            'code' => null,
+        ]);
+    }
+
+    /**
+     * Enable two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\EnableTwoFactorAuthentication  $enable
+     * @return void
+     */
+    public function enableTwoFactorAuthentication(EnableTwoFactorAuthentication $enable)
+    {
+        $enable(Auth::user());
+
+        $this->showingQrCode = true;
+
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
+            $this->showingConfirmation = true;
+        } else {
+            $this->showingRecoveryCodes = true;
+        }
+    }
+
+    /**
+     * Disable two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\DisableTwoFactorAuthentication  $disable
+     * @return void
+     */
+    public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable)
+    {
+        $disable(Auth::user());
+
+        $this->showingQrCode = false;
+        $this->showingConfirmation = false;
+        $this->showingRecoveryCodes = false;
+    }
+
+    /**
+     * Display the user's recovery codes.
+     *
+     * @return void
+     */
+    public function showRecoveryCodes()
+    {
+        $this->showingRecoveryCodes = true;
+    }
+
+    /**
+     * Generate new recovery codes for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\GenerateNewRecoveryCodes  $generate
+     * @return void
+     */
+    public function regenerateRecoveryCodes(GenerateNewRecoveryCodes $generate)
+    {
+        $generate(Auth::user());
+
+        $this->showingRecoveryCodes = true;
+    }
+
+    /**
+     * Confirm two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication  $confirm
+     * @return void
+     */
+    public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm)
+    {
+        $data = $this->form->getState();
+        $confirm(Auth::user(), $data['code']);
+
+        $this->showingQrCode = false;
+        $this->showingConfirmation = false;
+        $this->showingRecoveryCodes = true;
+    }
+
+    /**
+     * Input field for two factor authentication confirmation code
+     *
+     * @return array
+     */
+    protected function getFormSchema(): array
+    {
+        return [
+            TextInput::make('code')
+                ->label(__('filament-fortify::two-factor.fields.code.label'))
+                ->validationAttribute(__('filament-fortify::two-factor.fields.code.label'))
+                ->inlineLabel()
+                ->required(),
+        ];
+    }
+}

--- a/src/Pages/Concerns/ConfirmPassword.php
+++ b/src/Pages/Concerns/ConfirmPassword.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WyChoong\FilamentFortify\Pages\Concerns;
+
+trait ConfirmPassword
+{
+    /**
+     * Determine if the user's password has been recently confirmed.
+     *
+     * @param  int|null  $maximumSecondsSinceConfirmation
+     * @return bool
+     */
+    protected function passwordIsConfirmed($maximumSecondsSinceConfirmation = null)
+    {
+        $maximumSecondsSinceConfirmation = $maximumSecondsSinceConfirmation ?: config('auth.password_timeout', 900);
+
+        return (time() - session('auth.password_confirmed_at', 0)) < $maximumSecondsSinceConfirmation;
+    }
+
+    /**
+     * User password coinfirmation passed
+     */
+    protected function userConfirmedPassword(): void
+    {
+        session(['auth.password_confirmed_at' => time()]);
+    }
+}

--- a/src/Pages/Concerns/HasActionButtons.php
+++ b/src/Pages/Concerns/HasActionButtons.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace WyChoong\FilamentFortify\Pages\Concerns;
+
+use Filament\Pages\Actions\Action;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Filament\Forms\Components\TextInput;
+use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
+
+trait HasActionButtons
+{
+
+    protected ?array $cachedButtons = null;
+
+    protected function getCachedButtons(): array
+    {
+        if ($this->cachedButtons === null) {
+            $this->cacheButtons();
+        }
+
+        return $this->cachedButtons;
+    }
+
+    protected function cacheButtons(): void
+    {
+        $this->cachedButtons = collect($this->getButtons())
+            ->mapWithKeys(function (Action $action): array {
+                $action->livewire($this);
+
+                return [$action->getName() => $action];
+            })
+            ->toArray();
+    }
+
+    protected function getCachedAction(string $name): ?Action
+    {
+        return $this->getCachedButtons()[$name] ?? parent::getCachedAction($name);
+    }
+
+    protected function getButtons(): array | View | null
+    {
+        $confirmation = fn () => !$this->passwordIsConfirmed();
+
+        $confirmationForm = $confirmation() ? [
+            TextInput::make("current_password")
+                ->label(__("filament-fortify::two-factor.fields.current_password.label"))
+                ->dehydrateStateUsing(fn ($state) => filled($state))
+                ->required()
+                ->password()
+                ->inlineLabel()
+                ->rule("current_password")
+        ] : [];
+
+        $buttons = [
+            'enable' => [
+                'action' => 'enableTwoFactorAuthentication',
+            ],
+            'disable' => [
+                'action' => 'disableTwoFactorAuthentication',
+                'confirmation' => fn () => is_null(Auth::user()->two_factor_confirmed_at) ? false : $confirmation(),
+                'color' => 'danger',
+            ],
+            'regenerate' => [
+                'action' => 'regenerateRecoveryCodes',
+                'color' => 'secondary',
+            ],
+            'confirm' => [
+                'action' => 'confirmTwoFactorAuthentication',
+                'color' => 'success',
+            ],
+            'show-recovery-code' => [
+                'action' => 'showRecoveryCodes',
+                'color' => 'secondary',
+            ],
+        ];
+
+        return collect($buttons)->map(function ($button, $name) use ($confirmation, $confirmationForm) {
+            $action = $button['action'];
+            $buttonColor = $button['color'] ?? 'primary';
+            $confirmation = isset($button['confirmation']) ? $button['confirmation'] : $confirmation;
+
+            return Action::make($name)
+                ->label(__("filament-fortify::two-factor.buttons.{$name}.label"))
+                ->form($confirmation() ? $confirmationForm : [])
+                ->color($buttonColor)
+                ->action(function ($data) use ($action) {
+
+                    if (isset($data['current_password']) && $data['current_password']) {
+                        $this->userConfirmedPassword();
+                    }
+
+                    app()->call([$this, $action]);
+                })
+                ->modalHeading(__("filament-fortify::two-factor.confirm-password.modal-heading"))
+                ->modalSubheading(__("filament-fortify::two-factor.confirm-password.modal-subheading"))
+                ->requiresConfirmation($confirmation);
+        })->toArray();
+    }
+
+    /**
+     * Enable two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\EnableTwoFactorAuthentication  $enable
+     * @return void
+     */
+    abstract public function enableTwoFactorAuthentication(EnableTwoFactorAuthentication $enable);
+
+    /**
+     * Disable two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\DisableTwoFactorAuthentication  $disable
+     * @return void
+     */
+    abstract public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable);
+
+    /**
+     * Display the user's recovery codes.
+     *
+     * @return void
+     */
+    abstract public function showRecoveryCodes();
+
+    /**
+     * Generate new recovery codes for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\GenerateNewRecoveryCodes  $generate
+     * @return void
+     */
+    abstract public function regenerateRecoveryCodes(GenerateNewRecoveryCodes $generate);
+
+    /**
+     * Confirm two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication  $confirm
+     * @return void
+     */
+    abstract public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm);
+}

--- a/src/Pages/TwoFactor.php
+++ b/src/Pages/TwoFactor.php
@@ -2,28 +2,64 @@
 
 namespace WyChoong\FilamentFortify\Pages;
 
-use App\Models\User;
-use Filament\Facades\Filament;
 use Filament\Pages\Page;
+use Laravel\Fortify\Features;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
 use WyChoong\FilamentFortify\Facades\FilamentFortify;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 
 class TwoFactor extends Page
 {
+    use InteractsWithForms;
+
     protected static ?string $navigationIcon = "heroicon-o-document-text"; //config
+
     protected static string $view = "filament-fortify::filament.pages.two-factor";
 
-    public User $user;
-    public $new_password;
-    public $new_password_confirmation;
-    public $token_name;
-    public $abilities = [];
-    public $plain_text_token;
-    public $hasTeams;
+    /**
+     * Indicates if two factor authentication QR code is being displayed.
+     *
+     * @var bool
+     */
+    public $showingQrCode = false;
 
-    public $enableTwoFactor = false;
+    /**
+     * Indicates if the two factor authentication confirmation input and button are being displayed.
+     *
+     * @var bool
+     */
+    public $showingConfirmation = false;
+
+    /**
+     * Indicates if two factor authentication recovery codes are being displayed.
+     *
+     * @var bool
+     */
+    public $showingRecoveryCodes = false;
+
+    /**
+     * The OTP code for confirming two factor authentication.
+     *
+     * @var string|null
+     */
+    public $code;
 
     public function mount()
     {
+
+        if (
+            Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
+            is_null(Auth::user()->two_factor_confirmed_at)
+        ) {
+            app(DisableTwoFactorAuthentication::class)(Auth::user());
+        }
+
         if (session('status') == 'two-factor-authentication-enabled') {
             Filament::notify('success', __("filament-fortify::two-factor.messages.enabled"), true);
         }
@@ -49,5 +85,123 @@ class TwoFactor extends Page
     protected function getTitle(): string
     {
         return FilamentFortify::pageTitle();
+    }
+
+    /**
+     * Input field for two factor authentication confirmation code
+     *
+     * @return array
+     */
+    protected function getFormSchema(): array
+    {
+        return [
+            TextInput::make('code')
+                ->label(__('filament-fortify::two-factor.fields.code.label'))
+                ->validationAttribute(__('filament-fortify::two-factor.fields.code.label'))
+                ->inlineLabel()
+                ->required(),
+        ];
+    }
+
+    /**
+     * Show two factor authentication info.
+     *
+     * @return bool
+     */
+    private function showTwoFactor(): bool
+    {
+        return !empty(Auth::user()->two_factor_secret);
+    }
+
+    /**
+     * Enable two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\EnableTwoFactorAuthentication  $enable
+     * @return void
+     */
+    public function enableTwoFactorAuthentication(EnableTwoFactorAuthentication $enable)
+    {
+        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+        //     $this->ensurePasswordIsConfirmed();
+        // }
+
+        $enable(Auth::user());
+
+        $this->showingQrCode = true;
+
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
+            $this->showingConfirmation = true;
+        } else {
+            $this->showingRecoveryCodes = true;
+        }
+    }
+
+    /**
+     * Disable two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\DisableTwoFactorAuthentication  $disable
+     * @return void
+     */
+    public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable)
+    {
+        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+        //     $this->ensurePasswordIsConfirmed();
+        // }
+
+        $disable(Auth::user());
+
+        $this->showingQrCode = false;
+        $this->showingConfirmation = false;
+        $this->showingRecoveryCodes = false;
+    }
+
+    /**
+     * Display the user's recovery codes.
+     *
+     * @return void
+     */
+    public function showRecoveryCodes()
+    {
+        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+        //     $this->ensurePasswordIsConfirmed();
+        // }
+
+        $this->showingRecoveryCodes = true;
+    }
+
+    /**
+     * Generate new recovery codes for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\GenerateNewRecoveryCodes  $generate
+     * @return void
+     */
+    public function regenerateRecoveryCodes(GenerateNewRecoveryCodes $generate)
+    {
+        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+        //     $this->ensurePasswordIsConfirmed();
+        // }
+
+        $generate(Auth::user());
+
+        $this->showingRecoveryCodes = true;
+    }
+
+    /**
+     * Confirm two factor authentication for the user.
+     *
+     * @param  \Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication  $confirm
+     * @return void
+     */
+    public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm)
+    {
+        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+        //     $this->ensurePasswordIsConfirmed();
+        // }
+        $data = $this->form->getState();
+        $confirm(Auth::user(), $data['code']);
+
+        $this->showingQrCode = false;
+        $this->showingConfirmation = false;
+        $this->showingRecoveryCodes = true;
     }
 }

--- a/src/Pages/TwoFactor.php
+++ b/src/Pages/TwoFactor.php
@@ -6,52 +6,27 @@ use Filament\Pages\Page;
 use Laravel\Fortify\Features;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Auth;
-use Filament\Forms\Components\TextInput;
+
 use Filament\Forms\Concerns\InteractsWithForms;
-use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
 use WyChoong\FilamentFortify\Facades\FilamentFortify;
-use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
-use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+use WyChoong\FilamentFortify\Pages\Concerns;
 use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
 
 class TwoFactor extends Page
 {
-    use InteractsWithForms;
+    use Concerns\HasActionButtons;
+    use Concerns\ConfirmPassword;
+    use Concerns\ActionButtons {
+        mount as actionButtonsMount;
+    }
 
     protected static ?string $navigationIcon = "heroicon-o-document-text"; //config
 
     protected static string $view = "filament-fortify::filament.pages.two-factor";
 
-    /**
-     * Indicates if two factor authentication QR code is being displayed.
-     *
-     * @var bool
-     */
-    public $showingQrCode = false;
-
-    /**
-     * Indicates if the two factor authentication confirmation input and button are being displayed.
-     *
-     * @var bool
-     */
-    public $showingConfirmation = false;
-
-    /**
-     * Indicates if two factor authentication recovery codes are being displayed.
-     *
-     * @var bool
-     */
-    public $showingRecoveryCodes = false;
-
-    /**
-     * The OTP code for confirming two factor authentication.
-     *
-     * @var string|null
-     */
-    public $code;
-
     public function mount()
     {
+        $this->actionButtonsMount();
 
         if (
             Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
@@ -88,22 +63,6 @@ class TwoFactor extends Page
     }
 
     /**
-     * Input field for two factor authentication confirmation code
-     *
-     * @return array
-     */
-    protected function getFormSchema(): array
-    {
-        return [
-            TextInput::make('code')
-                ->label(__('filament-fortify::two-factor.fields.code.label'))
-                ->validationAttribute(__('filament-fortify::two-factor.fields.code.label'))
-                ->inlineLabel()
-                ->required(),
-        ];
-    }
-
-    /**
      * Show two factor authentication info.
      *
      * @return bool
@@ -111,97 +70,5 @@ class TwoFactor extends Page
     private function showTwoFactor(): bool
     {
         return !empty(Auth::user()->two_factor_secret);
-    }
-
-    /**
-     * Enable two factor authentication for the user.
-     *
-     * @param  \Laravel\Fortify\Actions\EnableTwoFactorAuthentication  $enable
-     * @return void
-     */
-    public function enableTwoFactorAuthentication(EnableTwoFactorAuthentication $enable)
-    {
-        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
-        //     $this->ensurePasswordIsConfirmed();
-        // }
-
-        $enable(Auth::user());
-
-        $this->showingQrCode = true;
-
-        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
-            $this->showingConfirmation = true;
-        } else {
-            $this->showingRecoveryCodes = true;
-        }
-    }
-
-    /**
-     * Disable two factor authentication for the user.
-     *
-     * @param  \Laravel\Fortify\Actions\DisableTwoFactorAuthentication  $disable
-     * @return void
-     */
-    public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable)
-    {
-        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
-        //     $this->ensurePasswordIsConfirmed();
-        // }
-
-        $disable(Auth::user());
-
-        $this->showingQrCode = false;
-        $this->showingConfirmation = false;
-        $this->showingRecoveryCodes = false;
-    }
-
-    /**
-     * Display the user's recovery codes.
-     *
-     * @return void
-     */
-    public function showRecoveryCodes()
-    {
-        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
-        //     $this->ensurePasswordIsConfirmed();
-        // }
-
-        $this->showingRecoveryCodes = true;
-    }
-
-    /**
-     * Generate new recovery codes for the user.
-     *
-     * @param  \Laravel\Fortify\Actions\GenerateNewRecoveryCodes  $generate
-     * @return void
-     */
-    public function regenerateRecoveryCodes(GenerateNewRecoveryCodes $generate)
-    {
-        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
-        //     $this->ensurePasswordIsConfirmed();
-        // }
-
-        $generate(Auth::user());
-
-        $this->showingRecoveryCodes = true;
-    }
-
-    /**
-     * Confirm two factor authentication for the user.
-     *
-     * @param  \Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication  $confirm
-     * @return void
-     */
-    public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm)
-    {
-        // if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
-        //     $this->ensurePasswordIsConfirmed();
-        // }
-        $data = $this->form->getState();
-        $confirm(Auth::user(), $data['code']);
-
-        $this->showingQrCode = false;
-        $this->showingConfirmation = false;
-        $this->showingRecoveryCodes = true;
     }
 }


### PR DESCRIPTION
Closes #6 

This is a flow for the fortify two factor confirm option. Which requires a user to enter the temporary code before two factor is actually enabled to prevent a user locking himself out. This PR also hides the QR code from the user and shows a disable button when the code is confirmed.

Which can be anabled in `config/fortify.php` like this:
```
Features::twoFactorAuthentication([
    'confirm' => true,
])
```
